### PR TITLE
use uuid as savepoint name

### DIFF
--- a/packages/crsqlite-wasm/src/TX.ts
+++ b/packages/crsqlite-wasm/src/TX.ts
@@ -96,16 +96,17 @@ export default class TX implements TXAsync {
 
   tx(cb: (tx: TXAsync) => Promise<void>): Promise<void> {
     this.assertOpen();
+    const id = crypto.randomUUID().replaceAll("-", "")
     return serializeTx(
       async (tx: TXAsync) => {
-        await tx.exec("SAVEPOINT crsql_transaction");
+        await tx.exec("SAVEPOINT " + id);
         try {
           await cb(tx);
         } catch (e) {
-          await tx.exec("ROLLBACK");
+          await tx.exec("ROLLBACK TO " + id);
           throw e;
         }
-        await tx.exec("RELEASE crsql_transaction");
+        await tx.exec("RELEASE " + id);
       },
       this.__mutex,
       this

--- a/packages/crsqlite-wasm/src/TX.ts
+++ b/packages/crsqlite-wasm/src/TX.ts
@@ -105,8 +105,9 @@ export default class TX implements TXAsync {
         } catch (e) {
           await tx.exec("ROLLBACK TO " + id);
           throw e;
+        } finally {
+          await tx.exec("RELEASE " + id);
         }
-        await tx.exec("RELEASE " + id);
       },
       this.__mutex,
       this

--- a/packages/crsqlite-wasm/src/TX.ts
+++ b/packages/crsqlite-wasm/src/TX.ts
@@ -104,10 +104,10 @@ export default class TX implements TXAsync {
           await cb(tx);
         } catch (e) {
           await tx.exec("ROLLBACK TO " + id);
-          throw e;
-        } finally {
           await tx.exec("RELEASE " + id);
+          throw e;
         }
+        await tx.exec("RELEASE " + id);
       },
       this.__mutex,
       this

--- a/packages/crsqlite-wasm/src/TX.ts
+++ b/packages/crsqlite-wasm/src/TX.ts
@@ -96,7 +96,7 @@ export default class TX implements TXAsync {
 
   tx(cb: (tx: TXAsync) => Promise<void>): Promise<void> {
     this.assertOpen();
-    const id = crypto.randomUUID().replaceAll("-", "")
+    const id = 'crsql' + crypto.randomUUID().replaceAll("-", "")
     return serializeTx(
       async (tx: TXAsync) => {
         await tx.exec("SAVEPOINT " + id);


### PR DESCRIPTION
The primary cause of this PR is this line from [the docs](https://www.sqlite.org/lang_savepoint.html):

> The ROLLBACK command without a TO clause rolls backs all transactions

I think the current behavior of busting out of all transactions seems too much. Note that even though the rollback causes _"The SAVEPOINT with the matching name [to] remains on the transaction stack"_, the subsequent RELEASE on L109 will (more or less) close out the transaction and commit nothing. _I think._ I've tested nothing 😅

I also made the names UUIDs because even though _"The transaction names need not be unique"_, it just _feels_ safer. Feel free to assuage me of my paranoia.