### PR TITLE
Track sync server connectivity

### DIFF
--- a/packages/ws-client/src/transport/Transport.ts
+++ b/packages/ws-client/src/transport/Transport.ts
@@ -31,4 +31,8 @@ export interface Transport {
   onResetStream: ((msg: StartStreaming) => Promise<void>) | null;
 
   close(): void;
+
+  // Connection lifecycle callbacks
+  onConnOpen?: (() => void) | null;
+  onConnClose?: (() => void) | null;
 }

--- a/packages/ws-client/src/transport/Transport.ts
+++ b/packages/ws-client/src/transport/Transport.ts
@@ -9,6 +9,8 @@ export type TransporOptions = {
   url: string;
   room: string;
   authToken?: string;
+  pingInterval?: number;
+  pingTimeout?: number;
 };
 
 export interface Transport {

--- a/packages/ws-client/src/transport/WebSocketTransport.ts
+++ b/packages/ws-client/src/transport/WebSocketTransport.ts
@@ -17,6 +17,10 @@ export default class WebSocketTransport implements Transport {
   #onReady: (() => void) | null = null;
   #keepAliveInterval: number | null = null;
 
+  // Connection event callbacks
+  onConnOpen: (() => void) | null = null;
+  onConnClose: (() => void) | null = null;
+
   constructor(options: TransporOptions) {
     this.#options = options;
   }
@@ -54,6 +58,16 @@ export default class WebSocketTransport implements Transport {
 
     socket.onopen = () => {
       if (this.#onReady) this.#onReady();
+      if (this.onConnOpen) this.onConnOpen();
+    };
+
+    socket.onclose = () => {
+      if (this.onConnClose) this.onConnClose();
+    };
+
+    socket.onerror = (error) => {
+      console.error("WebSocket error:", error);
+      if (this.onConnClose) this.onConnClose();
     };
 
     this.#socket = socket;

--- a/packages/ws-client/src/transport/WebSocketTransport.ts
+++ b/packages/ws-client/src/transport/WebSocketTransport.ts
@@ -17,9 +17,8 @@ export default class WebSocketTransport implements Transport {
   #onReady: (() => void) | null = null;
   #keepAliveInterval: number | null = null;
 
-  // Connection event callbacks
-  onConnOpen: (() => void) | null = null;
-  onConnClose: (() => void) | null = null;
+  #closeTimeout: number | null = null;
+  #pingTimeout: number | null = null;
 
   constructor(options: TransporOptions) {
     this.#options = options;
@@ -36,11 +35,14 @@ export default class WebSocketTransport implements Transport {
     }
 
     if (this.#keepAliveInterval == null) {
-      this.#keepAliveInterval = setInterval(() => {
-        if (!this.#socket || this.#socket?.readyState === WebSocket.CLOSED) {
-          this.#openSocketAndKeepAlive(options);
-        }
-      }, Math.random() * 2000 + 1000);
+      this.#keepAliveInterval = setInterval(
+        () => {
+          if (!this.#socket || this.#socket?.readyState === WebSocket.CLOSED) {
+            this.#openSocketAndKeepAlive(options);
+          }
+        },
+        Math.random() * 2000 + 1000
+      );
     }
 
     const socket = new WebSocket(options.url, [
@@ -59,14 +61,14 @@ export default class WebSocketTransport implements Transport {
     socket.onopen = () => {
       if (this.#onReady) this.#onReady();
       if (this.onConnOpen) this.onConnOpen();
+      this.#resetSignOfLife();
     };
 
     socket.onclose = () => {
       if (this.onConnClose) this.onConnClose();
     };
 
-    socket.onerror = (error) => {
-      console.error("WebSocket error:", error);
+    socket.onerror = () => {
       if (this.onConnClose) this.onConnClose();
     };
 
@@ -74,13 +76,55 @@ export default class WebSocketTransport implements Transport {
     return socket;
   }
 
+  #resetSignOfLife() {
+    if (this.#closeTimeout) {
+      clearTimeout(this.#closeTimeout);
+    }
+    if (this.#pingTimeout) {
+      clearTimeout(this.#pingTimeout);
+    }
+
+    const { pingInterval = 1000, pingTimeout = 500 } = this.#options;
+
+    this.#pingTimeout = setTimeout(() => {
+      if (this.#socket && this.#socket.readyState === WebSocket.OPEN) {
+        this.#socket.send(encode({ _tag: tags.Ping }));
+      }
+    }, pingInterval);
+
+    this.#closeTimeout = setTimeout(() => {
+      console.warn(
+        "No sign of life from server, closing socket, the connection will retry until explicitly closed"
+      );
+      this.#closeSocket();
+    }, pingInterval + pingTimeout);
+  }
+
+  // Works as a soft-close when connection drops:
+  // - the socket gets closed and cleared
+  // - internal this.#closed is still false -- keep retrying the connection
+  // - run #openSocketAndKeepaAlive (reseting the keep alive interval if not set + retrying the connection)
+  #closeSocket() {
+    this.#socket?.close();
+    this.#socket = null;
+    this.#openSocketAndKeepAlive(this.#options);
+  }
+
   onChangesReceived: ((msg: Changes) => Promise<void>) | null = null;
   onStartStreaming: ((msg: StartStreaming) => Promise<void>) | null = null;
   onResetStream: ((msg: StartStreaming) => Promise<void>) | null = null;
   onReconnected: (() => Promise<void>) | null = null;
 
+  // Connection event callbacks
+  onConnOpen: (() => void) | null = null;
+  onConnClose: (() => void) | null = null;
+
   #processEvent = (data: Uint8Array) => {
     const msg = decode(data);
+
+    // Any message from server is a sign of life
+    this.#resetSignOfLife();
+
     switch (msg._tag) {
       case tags.AnnouncePresence:
       case tags.RejectChanges:
@@ -98,6 +142,10 @@ export default class WebSocketTransport implements Transport {
           this.#hadStartStream = true;
           this.onStartStreaming && this.onStartStreaming(msg);
         }
+        return;
+      case tags.Pong:
+        // Right now pong is just a sign of life - handled above
+        // TODO: we might implement additional data with the pong / heartbeat in the future
         return;
     }
   };

--- a/packages/ws-server/src/ConnectionBroker.ts
+++ b/packages/ws-server/src/ConnectionBroker.ts
@@ -1,4 +1,4 @@
-import { Msg, decode, tags } from "@vlcn.io/ws-common";
+import { Msg, decode, encode, tags } from "@vlcn.io/ws-common";
 import SyncConnection, { createSyncConnection } from "./SyncConnection.js";
 import DBCache from "./DBCache.js";
 import { WebSocket } from "ws";
@@ -52,7 +52,12 @@ export default class ConnectionBroker {
 
   async #handleMessage(msg: Msg) {
     const tag = msg._tag;
+
     switch (tag) {
+      case tags.Ping: {
+        this.#ws.send(encode({ _tag: tags.Pong }));
+        return;
+      }
       // Note: room could go in the `AnnouncePresence` message instead of the random headers.
       case tags.AnnouncePresence: {
         logger.info(`AnnouncePresence for: ${this.#room}`);


### PR DESCRIPTION
Add the ability to track sync server connectivity:
* add `onConnOpen` and `onConnClose` to `Transport` interface
* extend `WebSocketTransport` to implement these methods

Current implementation:
* the client polls (pings the server) setting the timeout after which the connection is considered closed:
  - `onConnClose` is called
  - the socket is closed and connection retried at an interval
  - **note:** the transport is not considered closed at this point, it's merely retrying the connection (full close will stop it retrying)
* in case a sign of life from the server is received within the aforementioned timeout, the timeout is reset
* all server received messages are treated as a sign of life: both the explicit **pong** message, as well as any other server sent event

The timeout (how long we wait for sign of life) and interval (poll frequency) are configurable via `pingTimeout` and `pingInterval` transport options (respectively)